### PR TITLE
Fix(ws): subscription overflow

### DIFF
--- a/rpc/ws/types.go
+++ b/rpc/ws/types.go
@@ -65,8 +65,11 @@ type response struct {
 }
 
 type params struct {
-	Result       *stdjson.RawMessage `json:"result"`
-	Subscription int                 `json:"subscription"`
+	Result *stdjson.RawMessage `json:"result"`
+	// Subscription is the subscription ID. Using json.Number to handle potential
+	// integer values larger than int64, as specified by the Solana RPC docs.
+	// ref: https://solana.com/docs/rpc/websocket/slotsubscribe
+	Subscription stdjson.Number `json:"subscription"`
 }
 
 type Options struct {


### PR DESCRIPTION
The Solana websocket endpoint can return a subscription ID as an integer that is larger than Go's `int64` maximum value. This caused JSON unmarshaling to fail with an overflow error when receiving valid API responses.

This change modifies the `Subscription` field in the response `params` struct to `json.Number`. This type safely captures any numeric value during the initial parsing, preventing the error and making the client more resilient.

The comment for this field has also been updated to clarify the reasoning and link to the official documentation.